### PR TITLE
Implement `try_from_fmt`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,15 +342,15 @@ impl<const LEN: usize> AStr<LEN> {
         AStr::<RET_LEN>::from_utf8_array_unchecked(ret_buf)
     }
 
-    pub fn try_from_fmt(display: impl std::fmt::Display) -> Result<Self, std::fmt::Error> {
-        use std::fmt::Write;
+    pub fn try_from_fmt(display: impl core::fmt::Display) -> Result<Self, core::fmt::Error> {
+        use core::fmt::Write;
         let mut builder = FmtBuilder::new();
         write!(builder, "{}", display)?;
         builder.finalize()
     }
 }
 
-/// Private type to build an [`AStr`] from anything that can print to an [std::fmt::Write]
+/// Private type to build an [`AStr`] from anything that can print to an [core::fmt::Write]
 struct FmtBuilder<const LEN: usize> {
     len: usize,
     partial: AStr<LEN>,
@@ -364,24 +364,24 @@ impl<const LEN: usize> FmtBuilder<LEN> {
         }
     }
 
-    pub fn finalize(self) -> Result<AStr<LEN>, std::fmt::Error> {
+    pub fn finalize(self) -> Result<AStr<LEN>, core::fmt::Error> {
         if self.len == LEN {
             Ok(self.partial)
         } else {
-            Err(std::fmt::Error)
+            Err(core::fmt::Error)
         }
     }
 }
 
-impl<const LEN: usize> std::fmt::Write for FmtBuilder<LEN> {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+impl<const LEN: usize> core::fmt::Write for FmtBuilder<LEN> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
         let s_len = s.len();
         let offset = self.len;
 
-        self.len = self.len.checked_add(s_len).ok_or(std::fmt::Error)?;
+        self.len = self.len.checked_add(s_len).ok_or(core::fmt::Error)?;
 
-        let rest = self.partial.get_mut(offset..).ok_or(std::fmt::Error)?;
-        let rest_bounded = rest.get_mut(..s_len).ok_or(std::fmt::Error)?;
+        let rest = self.partial.get_mut(offset..).ok_or(core::fmt::Error)?;
+        let rest_bounded = rest.get_mut(..s_len).ok_or(core::fmt::Error)?;
 
         // SAFETY:
         // `rest_bounded` and `s` are both valid string slices.


### PR DESCRIPTION
This PR implements the feature discussed in #1, except the macro.

Regarding the error type of `AStr::try_from_fmt(fmt: impl core::fmt::Display) -> Result<Self, Error>`, I went with `std::fmt::Error` because none of the current variants of `AStrError` are really suited, and adding a new variant would be a breaking change. I can always go back to modify that if needed, or even introduce a new specific error type with "too big" and "too small" variants.

### Unsafe

There is a (documented) use of unsafe to copy an `&str` into an `&mut str` of identical size. I can't find any situation in which this would be unsound. If using `unsafe` is undesirable, I can probably implement this in a different way.

### Macro

_The macro is not currently on my branch, but I have it in another project of mine. I could also include it._

The macro I have in my personal implementation looks like this:
```rust
#[macro_export]
macro_rules! format_astr {
    (<$len:literal> $format:literal $(,$arg:tt)* $(,)?) => {{
        const LEN: usize = $len;
        let mut builder = $crate::FmtBuilder::<LEN>::new();

        use std::fmt::Write;
        match write!(builder, $format, $($arg),*) {
            Ok(()) => builder.finalize(),
            Err(err) => Err(err),
        }
    }};
    ($format:literal $(,$arg:tt)* $(,)?) => {{
        let mut builder = $crate::FmtBuilder::new();

        use std::fmt::Write;
        match write!(builder, $format, $($arg),*) {
            Ok(()) => builder.finalize(),
            Err(err) => Err(err),
        }
    }};
}
```

It works like the `format*!` family of macros, but you may also add `<LEN>` in front of the format string. I'm not sure if `LEN` can be made an `:expr` instead of a `:literal` though (to accept any const expression), the `>` delimiter might be ambiguous.  I can commit it here or in a next PR after more discussion, if you're interested. I'd take care to add tests and check syntax parity a bit more thoroughly.